### PR TITLE
Check for empty dns name before creating cname

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,7 +21,8 @@ class r53hostname (
     $record = "${service}.${zone}"
   }
 
-  if ($::ec2_metadata['public-hostname']) {
+  if ($::ec2_metadata['public-hostname']
+      and $::ec2_metadata['public-hostname'] != '') {
 
     route53_cname_record { $record:
       ensure => 'present',


### PR DESCRIPTION
If a public ip is associated with an instance and enableDnsHostnames is
not set for the VPC, the public-hostname will be an empty string rather
than undef.